### PR TITLE
Add AI adventure map

### DIFF
--- a/backend/data.json
+++ b/backend/data.json
@@ -2,65 +2,49 @@
   "countries": [
     {
       "id": 1,
-      "name": "AlphaLand",
-      "description": "Welcome to AlphaLand!",
+      "name": "Calculus Country",
+      "description": "Discover the world of calculus.",
+      "lat": 48.8566,
+      "lng": 2.3522,
       "unlocked": true
     },
     {
       "id": 2,
-      "name": "BetaLand",
-      "description": "Welcome to BetaLand!",
+      "name": "Statistics Country",
+      "description": "Explore statistics fundamentals.",
+      "lat": 51.5074,
+      "lng": -0.1278,
+      "unlocked": false
+    },
+    {
+      "id": 3,
+      "name": "Machine Learning Land",
+      "description": "Journey into machine learning.",
+      "lat": 37.7749,
+      "lng": -122.4194,
       "unlocked": false
     }
   ],
   "cities": [
-    {
-      "id": 1,
-      "countryId": 1,
-      "name": "Alphaville",
-      "unlocked": true
-    },
-    {
-      "id": 2,
-      "countryId": 1,
-      "name": "Numeria",
-      "unlocked": false
-    },
-    {
-      "id": 3,
-      "countryId": 2,
-      "name": "Betatown",
-      "unlocked": false
-    }
+    {"id": 1, "countryId": 1, "name": "Limits City", "unlocked": true},
+    {"id": 2, "countryId": 1, "name": "Derivatives City", "unlocked": false},
+    {"id": 3, "countryId": 2, "name": "Descriptive City", "unlocked": false},
+    {"id": 4, "countryId": 2, "name": "Probability City", "unlocked": false},
+    {"id": 5, "countryId": 3, "name": "Supervised City", "unlocked": false},
+    {"id": 6, "countryId": 3, "name": "Neural Net City", "unlocked": false}
   ],
   "districts": [
-    {
-      "id": 1,
-      "cityId": 1,
-      "name": "Harbor",
-      "concept": "Count the boats",
-      "unlocked": true
-    },
-    {
-      "id": 2,
-      "cityId": 1,
-      "name": "Market",
-      "concept": "Count the apples",
-      "unlocked": false
-    },
-    {
-      "id": 3,
-      "cityId": 2,
-      "name": "Square",
-      "concept": "Count the cars",
-      "unlocked": false
-    },
-    {
-      "id": 4,
-      "cityId": 3,
-      "name": "Center",
-      "concept": "Count the houses",
-      "unlocked": false
-    }
+    {"id": 1, "cityId": 1, "name": "Intro to Limits", "concept": "limits", "question": "What is lim_{x->0} x?", "options": ["0", "1", "Infinity"], "answer": 0, "unlocked": true},
+    {"id": 2, "cityId": 1, "name": "Continuity District", "concept": "continuity", "question": "A function is continuous if it has no...", "options": ["Gaps", "Values", "Slopes"], "answer": 0, "unlocked": false},
+    {"id": 3, "cityId": 2, "name": "Intro to Derivatives", "concept": "derivatives", "question": "The derivative measures rate of...", "options": ["Change", "Distance", "Volume"], "answer": 0, "unlocked": false},
+    {"id": 4, "cityId": 2, "name": "Chain Rule", "concept": "chainrule", "question": "The chain rule is used for...", "options": ["Composite functions", "Integrals", "Matrices"], "answer": 0, "unlocked": false},
+    {"id": 5, "cityId": 3, "name": "Mean & Median", "concept": "meanmedian", "question": "The mean of [2,4] is...", "options": ["3", "2", "4"], "answer": 0, "unlocked": false},
+    {"id": 6, "cityId": 3, "name": "Variance", "concept": "variance", "question": "Variance measures...", "options": ["Spread", "Sum", "Product"], "answer": 0, "unlocked": false},
+    {"id": 7, "cityId": 4, "name": "Basic Probability", "concept": "probability", "question": "Probability ranges from 0 to...", "options": ["1", "100", "10"], "answer": 0, "unlocked": false},
+    {"id": 8, "cityId": 4, "name": "Distributions", "concept": "distributions", "question": "Normal distribution is often called...", "options": ["Gaussian", "Poisson", "Uniform"], "answer": 0, "unlocked": false},
+    {"id": 9, "cityId": 5, "name": "Regression", "concept": "regression", "question": "Linear regression fits a...", "options": ["Line", "Circle", "Cube"], "answer": 0, "unlocked": false},
+    {"id": 10, "cityId": 5, "name": "Classification", "concept": "classification", "question": "Classification predicts...", "options": ["Categories", "Numbers", "Pixels"], "answer": 0, "unlocked": false},
+    {"id": 11, "cityId": 6, "name": "Neural Basics", "concept": "neuralbasics", "question": "A perceptron is a type of...", "options": ["Neuron", "Matrix", "Graph"], "answer": 0, "unlocked": false},
+    {"id": 12, "cityId": 6, "name": "Backpropagation", "concept": "backpropagation", "question": "Backpropagation computes...", "options": ["Gradients", "Images", "Sequences"], "answer": 0, "unlocked": false}
   ]
 }

--- a/frontend/app.js
+++ b/frontend/app.js
@@ -1,0 +1,151 @@
+// State
+let currentCountry = null;
+let currentCity = null;
+let currentDistrict = null;
+let map = null;
+
+const views = {
+  main: document.getElementById('main-menu'),
+  country: document.getElementById('country-view'),
+  city: document.getElementById('city-view'),
+  district: document.getElementById('district-view'),
+  game: document.getElementById('game-view'),
+  help: document.getElementById('help-overlay')
+};
+
+function showView(name) {
+  Object.values(views).forEach(v => v.classList.add('hidden'));
+  views[name].classList.remove('hidden');
+}
+
+// Event bindings
+
+document.getElementById('start-btn').addEventListener('click', loadCountries);
+document.getElementById('help-btn').addEventListener('click', () => views.help.classList.remove('hidden'));
+document.getElementById('close-help').addEventListener('click', () => views.help.classList.add('hidden'));
+document.getElementById('country-back').addEventListener('click', () => showView('main'));
+document.getElementById('city-back').addEventListener('click', () => loadCountries());
+document.getElementById('district-back').addEventListener('click', () => loadCities(currentCountry));
+document.getElementById('game-back').addEventListener('click', () => loadDistricts(currentCity));
+
+// Load countries and create map
+function loadCountries() {
+  fetch('/api/countries')
+    .then(r => r.json())
+    .then(countries => {
+      const list = document.getElementById('countries-list');
+      list.innerHTML = '';
+
+      if (map) {
+        map.remove();
+      }
+      map = L.map('map').setView([20, 0], 2);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        attribution: 'Map data © OpenStreetMap contributors'
+      }).addTo(map);
+
+      countries.forEach(country => {
+        const btn = document.createElement('button');
+        btn.textContent = country.name;
+        btn.className = 'country';
+        if (!country.unlocked) {
+          btn.classList.add('locked');
+        } else {
+          btn.addEventListener('click', () => {
+            currentCountry = country.id;
+            loadCities(country.id);
+          });
+        }
+        list.appendChild(btn);
+
+        const marker = L.marker([country.lat, country.lng]).addTo(map);
+        marker.bindPopup(country.name);
+        if (country.unlocked) {
+          marker.on('click', () => {
+            currentCountry = country.id;
+            loadCities(country.id);
+          });
+        }
+      });
+      showView('country');
+    });
+}
+
+function loadCities(countryId) {
+  fetch(`/api/countries/${countryId}/cities`)
+    .then(r => r.json())
+    .then(cities => {
+      const container = document.getElementById('cities-container');
+      container.innerHTML = '';
+      cities.forEach(city => {
+        const btn = document.createElement('button');
+        btn.textContent = city.name;
+        btn.className = 'city';
+        if (!city.unlocked) {
+          btn.classList.add('locked');
+        } else {
+          btn.addEventListener('click', () => {
+            currentCity = city.id;
+            loadDistricts(city.id);
+          });
+        }
+        container.appendChild(btn);
+      });
+      showView('city');
+    });
+}
+
+function loadDistricts(cityId) {
+  fetch(`/api/cities/${cityId}/districts`)
+    .then(r => r.json())
+    .then(districts => {
+      const container = document.getElementById('districts-container');
+      container.innerHTML = '';
+      districts.forEach(d => {
+        const btn = document.createElement('button');
+        btn.textContent = d.name;
+        btn.className = 'district';
+        if (!d.unlocked) {
+          btn.classList.add('locked');
+        } else {
+          btn.addEventListener('click', () => startGame(d));
+        }
+        container.appendChild(btn);
+      });
+      showView('district');
+    });
+}
+
+function startGame(district) {
+  currentDistrict = district;
+  document.getElementById('game-question').textContent = district.question;
+  const ans = document.getElementById('answer-buttons');
+  ans.innerHTML = '';
+  district.options.forEach((opt, idx) => {
+    const b = document.createElement('button');
+    b.textContent = opt;
+    b.addEventListener('click', () => checkAnswer(idx));
+    ans.appendChild(b);
+  });
+  showView('game');
+}
+
+function checkAnswer(idx) {
+  const correct = idx === currentDistrict.answer;
+  const view = document.getElementById('game-view');
+  if (correct) {
+    const msg = document.createElement('div');
+    msg.textContent = 'Correct!';
+    view.insertBefore(msg, view.firstChild);
+    fetch(`/api/districts/${currentDistrict.id}/complete`, { method: 'POST' })
+      .finally(() => {
+        setTimeout(() => {
+          msg.remove();
+          loadDistricts(currentCity);
+        }, 1000);
+      });
+  } else {
+    view.classList.add('shake');
+    setTimeout(() => view.classList.remove('shake'), 500);
+  }
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -3,27 +3,61 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Counting Concepts Game</title>
+  <title>AI Learning Adventure</title>
   <link rel="stylesheet" href="styles.css" />
+  <link
+    rel="stylesheet"
+    href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-sA+e2t7jKQw+y7E2kRfIzoAnhf3I1PvTLDG2jTD6lzM="
+    crossorigin=""
+  />
 </head>
 <body>
   <div id="main-menu" class="view">
-    <h1>Counting Adventure</h1>
-    <button id="start-btn">Start Game</button>
-    <button id="help-btn">Help</button>
-    <button id="settings-btn">Settings</button>
+    <h1>AI Adventure</h1>
+    <p>Travel the world and learn AI basics.</p>
+    <button id="start-btn">Start Journey</button>
+    <button id="help-btn">How to Play</button>
   </div>
 
   <div id="help-overlay" class="overlay hidden">
-    <p>Select a district and answer the counting question!</p>
-    <button id="close-help">Close</button>
+    <div class="help-content">
+      <h2>How to Play</h2>
+      <p>Select a course on the map, then pick a unit and answer the question to unlock the next topic.</p>
+      <button id="close-help">Close</button>
+    </div>
   </div>
 
-  <div id="country-view" class="view hidden"></div>
-  <div id="city-view" class="view hidden"></div>
-  <div id="district-view" class="view hidden"></div>
-  <div id="game-view" class="view hidden"></div>
+  <div id="country-view" class="view hidden">
+    <h2>Choose a Course</h2>
+    <div id="map" class="map"></div>
+    <div id="countries-list"></div>
+    <button id="country-back">Back</button>
+  </div>
 
+  <div id="city-view" class="view hidden">
+    <h2>Choose a Unit</h2>
+    <div id="cities-container"></div>
+    <button id="city-back">Back to Courses</button>
+  </div>
+
+  <div id="district-view" class="view hidden">
+    <h2>Choose a Topic</h2>
+    <div id="districts-container"></div>
+    <button id="district-back">Back to Units</button>
+  </div>
+
+  <div id="game-view" class="view hidden">
+    <h2 id="game-question"></h2>
+    <div id="answer-buttons" class="answer-container"></div>
+    <button id="game-back">Back to Topics</button>
+  </div>
+
+  <script
+    src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-o9N1j7kPANZ8WuoLz1gmbNqjduGrE0xRHXQoNfjihMw="
+    crossorigin=""
+  ></script>
   <script src="app.js"></script>
 </body>
 </html>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -4,7 +4,7 @@ body {
   background-color: #f0f8ff;
 }
 .view {
-  margin-top: 50px;
+  margin-top: 20px;
 }
 .hidden {
   display: none;
@@ -20,6 +20,11 @@ body {
   justify-content: center;
   align-items: center;
   color: #fff;
+}
+.map {
+  height: 300px;
+  width: 100%;
+  margin: 10px 0;
 }
 button {
   padding: 10px 20px;
@@ -49,4 +54,8 @@ button {
   60% { transform: translate(3px, 2px) rotate(0deg); }
   80% { transform: translate(1px, -1px) rotate(1deg); }
   100% { transform: translate(-1px, 2px) rotate(-1deg); }
+}
+.answer-container button {
+  display: inline-block;
+  margin: 5px;
 }


### PR DESCRIPTION
## Summary
- overhaul frontend to use Leaflet map and quiz-based gameplay
- add AI-focused data set with courses and units
- style updates for map and new UI

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`
- `npm run start`

------
https://chatgpt.com/codex/tasks/task_e_68437741f17883299c71c8898de10b03